### PR TITLE
Cached fallback

### DIFF
--- a/assets/style/style.css
+++ b/assets/style/style.css
@@ -108,6 +108,7 @@ ol, ul {
     padding: 10px;
     padding-bottom: 15px;
     margin-block: 10px;
+    border-radius:5px;
 }
 
 li {
@@ -124,7 +125,7 @@ img {
 .forecast-summary-entry {
     background: #d7d7d7;
     border-radius: 50px;
-    max-width: 90%;
+    width: 90%;
     padding-inline: 25px;
     box-shadow: 0px 7px 4px 0px #00000096;
     margin-block: 5px;
@@ -139,8 +140,11 @@ img {
 }
 
 
-.weather-summary{
-
+.weather-summary {
+    display: flex;
+    justify-content: center;
+    flex-direction:column;
+    align-items:center;
 }
 
 body {
@@ -388,6 +392,13 @@ label{
 
 .grid {
     margin-bottom: 200px;
+}
+
+.alert {
+    background: #d7d7d7;
+    padding: 10px;
+    border: 1px solid black;
+    border-radius:5px;
 }
 
 /*

--- a/index.html
+++ b/index.html
@@ -31,8 +31,8 @@
 
                 <button id="info-toggle" class="info-button">i</button>
                 <h2>Sunset + Richmond Forecast</h2>
-                <ul class="weather-summary" id="weather-summary">
-                </ul>
+                <div class="weather-summary" id="weather-summary">
+                </div>
 
 
                 <div class="blue-info-container">


### PR DESCRIPTION
This branch adds in the ability to fail gracefully. Occasionally, when fetching from the NWS API, the response comes back invalid because some hours are missing. There's no way to tell the API to just give you the hours it has, or to bound the Fetch request such that it only requests an always-safe number of hours. 

My solution is to save the forecast object in Local Storage. Then, if the response from the API is anything other than 200, we use the cached forecast. And if the cached forecast isn't present, we land in a Catch block that explains the situation to the user